### PR TITLE
Revamp landing page to mentorship-first layout with AI tools, Calendly booking and updated SEO

### DIFF
--- a/components/AlphaTradingLanding.js
+++ b/components/AlphaTradingLanding.js
@@ -1,686 +1,469 @@
 import React from 'react';
-import { ChevronDown, TrendingUp, Users, BookOpen, Zap, Bell, Play, CheckCircle, ArrowRight, Calendar, Clock, Target, BarChart3, MessageCircle, Mail } from 'lucide-react';
+import {
+  GraduationCap,
+  BookOpen,
+  Bot,
+  Users,
+  ArrowRight,
+  CheckCircle,
+  ClipboardList,
+  TrendingUp,
+  CalendarDays,
+  Shield,
+  MessageSquare,
+  PlayCircle,
+  BarChart3,
+  Target,
+  Compass,
+} from 'lucide-react';
+
+const calendlyUrl = 'https://calendly.com/bo-umair/charting-mentorship';
+
+const pillars = [
+  {
+    icon: GraduationCap,
+    title: 'Mentorship Program',
+    description: 'Live coaching and a structured path to help traders build discipline, confidence, and consistency.',
+  },
+  {
+    icon: BookOpen,
+    title: 'Trading Education',
+    description: 'Courses, strategy playbooks, journaling systems, and preparation frameworks.',
+  },
+  {
+    icon: Bot,
+    title: 'Algo Tools',
+    description: 'AI-assisted scanners and alerts to support decision-making with speed and structure.',
+  },
+  {
+    icon: Users,
+    title: 'Community',
+    description: 'Private Discord, webinars, chart reviews, and mentorship feedback from serious traders.',
+  },
+];
+
+const mentorshipModules = [
+  'Market structure and support/resistance',
+  'Options and futures market foundations',
+  'Technical setups and small-cap momentum',
+  'Scanner configuration and alert interpretation',
+  'Risk management and position sizing',
+  'Trade journaling and performance review',
+  'Weekly live chart reviews and Q&A',
+];
+
+const mentorshipTiers = [
+  {
+    title: 'Core Mentorship',
+    details: 'Best for traders who want structure, accountability, and weekly direction.',
+  },
+  {
+    title: 'Mentorship + Tools',
+    details: 'Includes mentorship plus AI-assisted scanner tools for faster opportunity detection.',
+  },
+  {
+    title: 'Private Intensive',
+    details: 'A selective hands-on track with deeper feedback and direct execution coaching.',
+  },
+];
+
+const playbooks = [
+  'Pre-Market Momentum Strategy',
+  'VWAP Reclaim Strategy',
+  'Short Squeeze Strategy',
+  'Support Bounce Strategy',
+  'Breakout Continuation Strategy',
+];
+
+const routine = [
+  'Market news and economic events',
+  'Top pre-market movers',
+  'Relative volume and momentum scans',
+  'Key support and resistance levels',
+  'Daily trade plan and risk parameters',
+];
+
+const botFeatures = [
+  'Pre-market scanners',
+  'Real-time alerts',
+  'Momentum detection',
+  'Liquidity sweep detection',
+  'Breakout notifications',
+];
 
 const AlphaTradingLanding = () => {
   const scrollToSection = (id) => {
     document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
   };
 
-  const handleJoinNow = () => {
-    window.open('https://buy.stripe.com/dRmdR876a15ebf183c5os0a', '_blank');
+  const handleBookIntro = () => {
+    window.open(calendlyUrl, '_blank', 'noopener,noreferrer');
   };
 
   return (
-    <div style={{
-      minHeight: '100vh',
-      background: 'linear-gradient(135deg, #0f172a 0%, #1e40af 50%, #0f172a 100%)',
-      color: 'white'
-    }}>
-      {/* Navigation */}
-      <nav style={{
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
-        zIndex: 50,
-        padding: '1.5rem'
-      }}>
-        <div style={{
-          maxWidth: '1200px',
-          margin: '0 auto',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between'
-        }}>
+    <div
+      style={{
+        minHeight: '100vh',
+        background: 'linear-gradient(135deg, #0f172a 0%, #1d4ed8 45%, #111827 100%)',
+        color: 'white',
+      }}
+    >
+      <nav
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 40,
+          backdropFilter: 'blur(8px)',
+          backgroundColor: 'rgba(15, 23, 42, 0.75)',
+          borderBottom: '1px solid rgba(148, 163, 184, 0.2)',
+        }}
+      >
+        <div
+          style={{
+            maxWidth: '1100px',
+            margin: '0 auto',
+            padding: '1rem 1.5rem',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '1rem',
+            flexWrap: 'wrap',
+          }}
+        >
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-{/* Your Actual Alpha Logo */}
-<div style={{ width: '3rem', height: '3rem', position: 'relative' }}>
-  <img 
-    src="/Alpha Trading.png" 
-    alt="Alpha Trading Logo" 
-    style={{ width: '100%', height: '100%', objectFit: 'contain' }}
-  />
-</div>
-            </div>
-            <div style={{ fontSize: '1.25rem', fontWeight: 'bold', color: 'white' }}>Alpha Trading Pros</div>
+            <img src="/Alpha Trading.png" alt="Alpha Trading logo" style={{ width: '2.25rem', height: '2.25rem' }} />
+            <div style={{ fontWeight: 700, fontSize: '1.1rem' }}>Alpha Trading Pro</div>
           </div>
-          <button 
-            onClick={handleJoinNow}
-            style={{
-              backgroundColor: '#10b981',
-              color: 'white',
-              fontWeight: '600',
-              padding: '0.5rem 1.5rem',
-              borderRadius: '0.5rem',
-              border: 'none',
-              cursor: 'pointer',
-              transition: 'background-color 0.3s'
-            }}
-            onMouseOver={(e) => e.target.style.backgroundColor = '#059669'}
-            onMouseOut={(e) => e.target.style.backgroundColor = '#10b981'}
-          >
-            Subscribe Now
-          </button>
+          <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+            <button
+              onClick={() => scrollToSection('mentorship')}
+              style={{
+                border: 'none',
+                cursor: 'pointer',
+                borderRadius: '0.6rem',
+                padding: '0.6rem 1rem',
+                background: 'linear-gradient(90deg, #10b981, #14b8a6)',
+                color: 'white',
+                fontWeight: 700,
+              }}
+            >
+              Join the Mentorship
+            </button>
+            <button
+              onClick={handleBookIntro}
+              style={{
+                border: '1px solid rgba(147, 197, 253, 0.6)',
+                cursor: 'pointer',
+                borderRadius: '0.6rem',
+                padding: '0.6rem 1rem',
+                background: 'transparent',
+                color: '#dbeafe',
+                fontWeight: 600,
+              }}
+            >
+              Book Intro Call
+            </button>
+          </div>
         </div>
       </nav>
 
-      {/* Hero Section */}
-      <section style={{
-        position: 'relative',
-        minHeight: '100vh',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        overflow: 'hidden',
-        paddingTop: '5rem'
-      }}>
-        <div style={{
-          position: 'relative',
-          zIndex: 10,
-          textAlign: 'center',
-          padding: '0 1.5rem',
-          maxWidth: '1200px',
-          margin: '0 auto'
-        }}>
-          <div style={{
-            marginBottom: '2rem',
-            display: 'inline-flex',
-            alignItems: 'center',
-            backgroundColor: 'rgba(16, 185, 129, 0.2)',
-            border: '1px solid rgba(16, 185, 129, 0.3)',
-            borderRadius: '9999px',
-            padding: '0.5rem 1.5rem',
-            backdropFilter: 'blur(4px)'
-          }}>
-            <TrendingUp style={{ width: '1.25rem', height: '1.25rem', marginRight: '0.5rem', color: '#10b981' }} />
-            <span style={{ color: '#10b981', fontWeight: '500' }}>Live Trading Signals</span>
-          </div>
-
-          <h1 style={{
-            fontSize: 'clamp(2.5rem, 8vw, 4.5rem)',
-            fontWeight: 'bold',
-            marginBottom: '1.5rem',
-            background: 'linear-gradient(to right, white, #bfdbfe, #10b981)',
-            WebkitBackgroundClip: 'text',
-            backgroundClip: 'text',
-            WebkitTextFillColor: 'transparent',
-            lineHeight: '1.1'
-          }}>
-            Turn Market Moves into
-            <span style={{ display: 'block', color: '#10b981' }}>Profits</span>
-          </h1>
-
-          <p style={{
-            fontSize: 'clamp(1rem, 3vw, 1.5rem)',
-            marginBottom: '3rem',
-            color: '#cbd5e1',
-            maxWidth: '48rem',
-            margin: '0 auto 3rem auto',
-            lineHeight: '1.6'
-          }}>
-            Get live trading signals, monthly webinars, and exclusive educational resources to trade smarter with options and futures.
+      <section style={{ padding: '5.5rem 1.5rem 4rem' }}>
+        <div style={{ maxWidth: '1000px', margin: '0 auto', textAlign: 'center' }}>
+          <p style={{ color: '#6ee7b7', fontWeight: 700, marginBottom: '1rem' }}>
+            Learn to Trade with Structure — Not Guesswork
           </p>
-
-          <button 
-            onClick={handleJoinNow}
-            style={{
-              position: 'relative',
-              background: 'linear-gradient(to right, #10b981, #2563eb)',
-              color: 'white',
-              fontWeight: 'bold',
-              padding: '1.5rem 3rem',
-              borderRadius: '0.75rem',
-              fontSize: '1.25rem',
-              border: 'none',
-              cursor: 'pointer',
-              transition: 'all 0.3s',
-              boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: '0.75rem'
-            }}
-            onMouseOver={(e) => {
-              e.target.style.transform = 'scale(1.05)';
-              e.target.style.boxShadow = '0 25px 50px -12px rgba(16, 185, 129, 0.25)';
-            }}
-            onMouseOut={(e) => {
-              e.target.style.transform = 'scale(1)';
-              e.target.style.boxShadow = '0 25px 50px -12px rgba(0, 0, 0, 0.25)';
-            }}
-          >
-            <span style={{ position: 'relative', zIndex: 10, display: 'flex', alignItems: 'center' }}>
-              Join Now – Start Your Trading Journey
-              <ArrowRight style={{ marginLeft: '0.75rem', width: '1.5rem', height: '1.5rem' }} />
-            </span>
-          </button>
-
-          <div style={{ marginTop: '4rem' }}>
-            <ChevronDown style={{ width: '2rem', height: '2rem', margin: '0 auto', color: '#64748b', animation: 'bounce 2s infinite' }} />
-          </div>
-        </div>
-      </section>
-
-      {/* About/Credibility Section */}
-      <section style={{ padding: '5rem 0' }}>
-        <div style={{ maxWidth: '64rem', margin: '0 auto', padding: '0 1.5rem', textAlign: 'center' }}>
-          <div style={{
-            backgroundColor: 'rgba(30, 41, 59, 0.3)',
-            backdropFilter: 'blur(16px)',
-            borderRadius: '1rem',
-            padding: '3rem',
-            border: '1px solid rgba(71, 85, 105, 0.5)'
-          }}>
-            <div style={{
-              width: '6rem',
-              height: '6rem',
-              background: 'linear-gradient(to bottom right, #10b981, #2563eb)',
-              borderRadius: '50%',
-              margin: '0 auto 2rem auto',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center'
-            }}>
-              <TrendingUp style={{ width: '3rem', height: '3rem', color: 'white' }} />
-            </div>
-            
-            <h2 style={{ fontSize: '2rem', fontWeight: 'bold', marginBottom: '1.5rem' }}>Meet Your Trading Guide</h2>
-            
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '2rem', marginBottom: '2rem' }}>
-              <div style={{ textAlign: 'center' }}>
-                <div style={{ color: '#10b981', fontWeight: 'bold', fontSize: '1.5rem' }}>MBA</div>
-                <div style={{ color: '#cbd5e1' }}>Specializing in CFA</div>
-              </div>
-              <div style={{ textAlign: 'center' }}>
-                <div style={{ color: '#3b82f6', fontWeight: 'bold', fontSize: '1.5rem' }}>2019</div>
-                <div style={{ color: '#cbd5e1' }}>Trading Options Since</div>
-              </div>
-              <div style={{ textAlign: 'center' }}>
-                <div style={{ color: '#a855f7', fontWeight: 'bold', fontSize: '1.5rem' }}>Recent</div>
-                <div style={{ color: '#cbd5e1' }}>Started Futures Trading</div>
-              </div>
-            </div>
-            
-            <p style={{ fontSize: '1.125rem', color: '#cbd5e1', lineHeight: '1.6' }}>
-              I'm focused on documenting my trading journey and sharing actionable signals that work. 
-              My mission is to help retail traders navigate the markets with confidence through proven strategies and real-time insights.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      {/* Subscription Offer Section */}
-      <section id="subscription" style={{
-        padding: '5rem 0',
-        background: 'linear-gradient(to bottom right, rgba(30, 41, 59, 0.5), rgba(37, 99, 235, 0.5))'
-      }}>
-        <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '0 1.5rem' }}>
-          <div style={{ textAlign: 'center', marginBottom: '4rem' }}>
-            <h2 style={{ fontSize: 'clamp(2rem, 5vw, 3rem)', fontWeight: 'bold', marginBottom: '1.5rem' }}>
-              What You Get as an
-              <span style={{ color: '#10b981' }}> Alpha Trading Subscriber</span>
-            </h2>
-            <p style={{ fontSize: '1.25rem', color: '#cbd5e1', maxWidth: '48rem', margin: '0 auto' }}>
-              Everything you need to trade smarter, learn faster, and profit consistently
-            </p>
-          </div>
-
-          <div style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
-            gap: '2rem',
-            marginBottom: '4rem'
-          }}>
-            {[
-              { icon: Calendar, title: 'Monthly Webinars', desc: 'Exclusive strategies, live Q&A sessions, and market analysis', color: '#10b981' },
-              { icon: Zap, title: 'Live Trading Signals', desc: 'Real-time alerts delivered via WhatsApp or Telegram', color: '#3b82f6' },
-              { icon: Play, title: 'Recorded Webinars', desc: 'Access to all past sessions – watch anytime, anywhere', color: '#a855f7' },
-              { icon: BookOpen, title: 'Educational Mini-Series', desc: 'Learn trading foundations from beginner to advanced', color: '#f59e0b' },
-              { icon: Target, title: 'Resources & Reading Lists', desc: 'Curated trading books and premium materials', color: '#06b6d4' },
-              { icon: Bell, title: 'Market News Alerts', desc: 'Live market-moving news delivered via Telegram', color: '#ef4444' },
-              { icon: Mail, title: 'Weekly Newsletter', desc: 'Market insights, trade recaps, and upcoming opportunities', color: '#eab308' }
-            ].map((feature, index) => (
-              <div key={index} style={{
-                backgroundColor: 'rgba(30, 41, 59, 0.4)',
-                backdropFilter: 'blur(16px)',
-                borderRadius: '0.75rem',
-                padding: '2rem',
-                border: '1px solid rgba(71, 85, 105, 0.5)',
-                transition: 'all 0.3s',
-                cursor: 'pointer'
-              }}
-              onMouseOver={(e) => {
-                e.currentTarget.style.borderColor = feature.color;
-                e.currentTarget.querySelector('.icon').style.transform = 'scale(1.1)';
-              }}
-              onMouseOut={(e) => {
-                e.currentTarget.style.borderColor = 'rgba(71, 85, 105, 0.5)';
-                e.currentTarget.querySelector('.icon').style.transform = 'scale(1)';
-              }}
-              >
-                <feature.icon className="icon" style={{
-                  width: '3rem',
-                  height: '3rem',
-                  color: feature.color,
-                  marginBottom: '1.5rem',
-                  transition: 'transform 0.3s'
-                }} />
-                <h3 style={{ fontSize: '1.25rem', fontWeight: 'bold', marginBottom: '1rem' }}>{feature.title}</h3>
-                <p style={{ color: '#cbd5e1' }}>{feature.desc}</p>
-              </div>
-            ))}
-          </div>
-
-          <div style={{ textAlign: 'center' }}>
-            <div style={{
-              background: 'linear-gradient(to right, rgba(16, 185, 129, 0.2), rgba(37, 99, 235, 0.2))',
-              borderRadius: '1rem',
-              padding: '2rem',
-              marginBottom: '2rem',
-              border: '1px solid rgba(16, 185, 129, 0.3)'
-            }}>
-              <div style={{ fontSize: '2.5rem', fontWeight: 'bold', color: '#10b981', marginBottom: '0.5rem' }}>$159.99</div>
-              <div style={{ fontSize: '1.25rem', color: '#cbd5e1' }}>per month</div>
-              <div style={{ fontSize: '0.875rem', color: '#64748b', marginTop: '0.5rem' }}>Cancel anytime • No long-term commitment</div>
-            </div>
-            
-            <button 
-              onClick={handleJoinNow}
+          <h1 style={{ fontSize: 'clamp(2rem, 6vw, 4rem)', lineHeight: 1.1, marginBottom: '1.25rem' }}>
+            Master the Markets with Structure and Discipline
+          </h1>
+          <p style={{ color: '#cbd5e1', fontSize: '1.15rem', maxWidth: '760px', margin: '0 auto 2rem' }}>
+            Alpha Trading provides a structured mentorship program designed to help traders develop real skills,
+            build confidence, and execute with a repeatable strategy across options and futures.
+          </p>
+          <div style={{ display: 'flex', justifyContent: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
+            <button
+              onClick={() => scrollToSection('mentorship')}
               style={{
-                background: 'linear-gradient(to right, #10b981, #2563eb)',
-                color: 'white',
-                fontWeight: 'bold',
-                padding: '1.5rem 3rem',
-                borderRadius: '0.75rem',
-                fontSize: '1.25rem',
                 border: 'none',
                 cursor: 'pointer',
-                transition: 'all 0.3s',
-                boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)'
-              }}
-              onMouseOver={(e) => {
-                e.target.style.transform = 'scale(1.05)';
-                e.target.style.boxShadow = '0 25px 50px -12px rgba(16, 185, 129, 0.25)';
-              }}
-              onMouseOut={(e) => {
-                e.target.style.transform = 'scale(1)';
-                e.target.style.boxShadow = '0 25px 50px -12px rgba(0, 0, 0, 0.25)';
+                borderRadius: '0.8rem',
+                padding: '0.95rem 1.4rem',
+                background: 'linear-gradient(90deg, #10b981, #2563eb)',
+                color: 'white',
+                fontWeight: 700,
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.4rem',
               }}
             >
-              Subscribe Now – Start Trading Smarter
+              Join the Mentorship <ArrowRight size={16} />
+            </button>
+            <button
+              onClick={() => scrollToSection('tools')}
+              style={{
+                border: '1px solid rgba(125, 211, 252, 0.7)',
+                cursor: 'pointer',
+                borderRadius: '0.8rem',
+                padding: '0.95rem 1.4rem',
+                background: 'transparent',
+                color: '#dbeafe',
+                fontWeight: 700,
+              }}
+            >
+              View Trading Tools
+            </button>
+            <button
+              onClick={handleBookIntro}
+              style={{
+                border: '1px solid rgba(110, 231, 183, 0.9)',
+                cursor: 'pointer',
+                borderRadius: '0.8rem',
+                padding: '0.95rem 1.4rem',
+                background: 'rgba(16, 185, 129, 0.15)',
+                color: '#d1fae5',
+                fontWeight: 700,
+              }}
+            >
+              Book Demo / Intro Session
             </button>
           </div>
         </div>
       </section>
 
-      {/* ORB Strategy Teaser */}
-      <section style={{ padding: '5rem 0' }}>
-        <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '0 1.5rem' }}>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(400px, 1fr))', gap: '3rem', alignItems: 'center' }}>
-            <div>
-              <h2 style={{ fontSize: '2.5rem', fontWeight: 'bold', marginBottom: '1.5rem' }}>
-                Master the <span style={{ color: '#10b981' }}>ORB Strategy</span>
-              </h2>
-              
-              <div style={{ marginBottom: '2rem' }}>
-                {[
-                  { color: '#10b981', title: 'Mark Pre-Market High (PMH) & Pre-Market Low (PML)', desc: 'Identify key levels before market open' },
-                  { color: '#3b82f6', title: 'Break Above = Calls (Bullish)', desc: 'Enter long positions on upward breakouts' },
-                  { color: '#a855f7', title: 'Break Below = Puts (Bearish)', desc: 'Enter short positions on downward breakouts' },
-                  { color: '#ef4444', title: 'Avoid the "No Trade Zone"', desc: 'Stay disciplined and wait for clear signals' }
-                ].map((item, index) => (
-                  <div key={index} style={{ display: 'flex', alignItems: 'flex-start', marginBottom: '1.5rem' }}>
-                    <CheckCircle style={{ width: '1.5rem', height: '1.5rem', color: item.color, marginTop: '0.25rem', marginRight: '1rem', flexShrink: 0 }} />
-                    <div>
-                      <div style={{ fontWeight: '600', marginBottom: '0.25rem' }}>{item.title}</div>
-                      <div style={{ color: '#cbd5e1' }}>{item.desc}</div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-              
-              <button 
-                onClick={handleJoinNow}
-                style={{
-                  background: 'linear-gradient(to right, #10b981, #2563eb)',
-                  color: 'white',
-                  fontWeight: 'bold',
-                  padding: '1rem 2rem',
-                  borderRadius: '0.75rem',
-                  border: 'none',
-                  cursor: 'pointer',
-                  transition: 'all 0.3s'
-                }}
-                onMouseOver={(e) => e.target.style.transform = 'scale(1.05)'}
-                onMouseOut={(e) => e.target.style.transform = 'scale(1)'}
-              >
-                Learn This Strategy in Our Monthly Webinars
-              </button>
+      <section style={{ padding: '1.5rem', maxWidth: '1100px', margin: '0 auto' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '1rem' }}>
+          {pillars.map((pillar) => (
+            <div
+              key={pillar.title}
+              style={{
+                backgroundColor: 'rgba(30, 41, 59, 0.55)',
+                border: '1px solid rgba(148, 163, 184, 0.25)',
+                borderRadius: '0.9rem',
+                padding: '1.2rem',
+              }}
+            >
+              <pillar.icon style={{ color: '#34d399', marginBottom: '0.75rem' }} />
+              <h3 style={{ marginBottom: '0.45rem' }}>{pillar.title}</h3>
+              <p style={{ color: '#cbd5e1', fontSize: '0.95rem' }}>{pillar.description}</p>
             </div>
-            
-            <div style={{
-              backgroundColor: 'rgba(30, 41, 59, 0.3)',
-              backdropFilter: 'blur(16px)',
-              borderRadius: '1rem',
-              padding: '2rem',
-              border: '1px solid rgba(71, 85, 105, 0.5)'
-            }}>
-              <div style={{ textAlign: 'center', marginBottom: '1.5rem' }}>
-                <h3 style={{ fontSize: '1.25rem', fontWeight: 'bold' }}>ORB Strategy Visualization</h3>
-              </div>
-              
-              <div style={{
-                position: 'relative',
-                height: '16rem',
-                backgroundColor: 'rgba(15, 23, 42, 0.5)',
-                borderRadius: '0.5rem',
-                padding: '1rem'
-              }}>
-                <div style={{
-                  position: 'absolute',
-                  top: '2rem',
-                  left: '1rem',
-                  right: '1rem',
-                  borderTop: '2px dashed #10b981'
-                }}>
-                  <div style={{ fontSize: '0.75rem', color: '#10b981', marginTop: '-0.75rem' }}>PMH</div>
-                </div>
-                
-                <div style={{
-                  position: 'absolute',
-                  bottom: '2rem',
-                  left: '1rem',
-                  right: '1rem',
-                  borderTop: '2px dashed #ef4444'
-                }}>
-                  <div style={{ fontSize: '0.75rem', color: '#ef4444', marginTop: '-0.75rem' }}>PML</div>
-                </div>
-                
-                <div style={{
-                  position: 'absolute',
-                  top: '50%',
-                  left: '1rem',
-                  right: '1rem',
-                  transform: 'translateY(-50%)',
-                  backgroundColor: 'rgba(234, 179, 8, 0.2)',
-                  height: '4rem',
-                  borderRadius: '0.25rem',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center'
-                }}>
-                  <span style={{ color: '#eab308', fontSize: '0.875rem', fontWeight: '500' }}>No Trade Zone</span>
-                </div>
-                
-                <div style={{ position: 'absolute', top: '0.5rem', right: '1rem', fontSize: '0.75rem', color: '#10b981' }}>📈 Calls Zone</div>
-                <div style={{ position: 'absolute', bottom: '0.5rem', right: '1rem', fontSize: '0.75rem', color: '#ef4444' }}>📉 Puts Zone</div>
-              </div>
-            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="mentorship" style={{ padding: '4.5rem 1.5rem' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <h2 style={{ fontSize: 'clamp(1.8rem, 4vw, 2.8rem)', marginBottom: '0.75rem' }}>Alpha Trading Mentorship Program</h2>
+          <p style={{ color: '#cbd5e1', maxWidth: '850px', marginBottom: '1.5rem' }}>
+            This is not a signals group. This is a trading education community designed to help traders understand
+            markets, build discipline, and develop independent decision-making.
+          </p>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '1rem' }}>
+            <InfoCard icon={GraduationCap} title="Structured Curriculum" items={mentorshipModules} />
+            <InfoCard
+              icon={CalendarDays}
+              title="Weekly Live Mentorship Sessions"
+              items={['Strategy breakdowns', 'Live chart reviews', 'Q&A sessions', 'Trade walkthroughs']}
+            />
+            <InfoCard
+              icon={ClipboardList}
+              title="Trading Journal System"
+              items={['Track daily trades', 'Review weekly performance', 'Log mistakes and lessons learned']}
+            />
+            <InfoCard
+              icon={Users}
+              title="Private Trading Community"
+              items={['Discord access', 'Strategy discussions', 'Trade reviews', 'Mentorship feedback']}
+            />
+          </div>
+
+          <div
+            style={{
+              marginTop: '1rem',
+              backgroundColor: 'rgba(15, 23, 42, 0.65)',
+              border: '1px solid rgba(52, 211, 153, 0.35)',
+              borderRadius: '0.9rem',
+              padding: '1.2rem',
+            }}
+          >
+            <h3 style={{ marginBottom: '0.6rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <BookOpen size={20} color="#6ee7b7" /> Alpha Trading Welcome Kit
+            </h3>
+            <p style={{ color: '#cbd5e1' }}>
+              New members receive a physical package including a strategy journal, trading playbook, pre-market
+              checklist guide, and trade logging system to reinforce discipline and execution.
+            </p>
           </div>
         </div>
       </section>
 
-      {/* Testimonials Section */}
-      <section style={{
-        padding: '5rem 0',
-        background: 'linear-gradient(to right, rgba(30, 41, 59, 0.5), rgba(126, 34, 206, 0.3))'
-      }}>
-        <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '0 1.5rem' }}>
-          <div style={{ textAlign: 'center', marginBottom: '4rem' }}>
-            <h2 style={{ fontSize: 'clamp(2rem, 5vw, 3rem)', fontWeight: 'bold', marginBottom: '1.5rem' }}>
-              What Our <span style={{ color: '#10b981' }}>Alpha Traders</span> Are Saying
-            </h2>
-            <p style={{ fontSize: '1.25rem', color: '#cbd5e1', maxWidth: '48rem', margin: '0 auto' }}>
-              Real results from real traders who've transformed their trading with our signals and strategies
+      <section style={{ padding: '0 1.5rem 4rem' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <h2 style={{ marginBottom: '1rem' }}>Mentorship Tiers</h2>
+          <p style={{ color: '#cbd5e1', marginBottom: '1rem' }}>
+            You can share your final tier names/pricing anytime and we can plug them in directly.
+          </p>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', gap: '1rem' }}>
+            {mentorshipTiers.map((tier) => (
+              <div key={tier.title} style={{ backgroundColor: 'rgba(30, 41, 59, 0.55)', borderRadius: '0.9rem', padding: '1rem', border: '1px solid rgba(148,163,184,0.3)' }}>
+                <h3 style={{ marginBottom: '0.5rem' }}>{tier.title}</h3>
+                <p style={{ color: '#cbd5e1' }}>{tier.details}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="tools" style={{ padding: '4.5rem 1.5rem', backgroundColor: 'rgba(15, 23, 42, 0.45)' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto', display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1.25rem' }}>
+          <div>
+            <h2 style={{ fontSize: 'clamp(1.7rem, 4vw, 2.4rem)', marginBottom: '0.75rem' }}>AI-Assisted Market Scanning</h2>
+            <p style={{ color: '#cbd5e1', marginBottom: '1rem' }}>
+              Our algorithmic scanning tools monitor market activity and identify potential opportunities using
+              relative volume spikes, float rotation, breakout levels, and technical structure.
+            </p>
+            {botFeatures.map((feature) => (
+              <div key={feature} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.55rem' }}>
+                <CheckCircle size={16} color="#34d399" />
+                <span style={{ color: '#e2e8f0' }}>{feature}</span>
+              </div>
+            ))}
+            <p style={{ color: '#93c5fd', marginTop: '1rem', fontWeight: 600 }}>
+              Important: Bots are tools that support traders. They are not guaranteed trade signals.
             </p>
           </div>
+          <div
+            style={{
+              borderRadius: '0.9rem',
+              border: '1px solid rgba(148, 163, 184, 0.3)',
+              backgroundColor: 'rgba(30, 41, 59, 0.55)',
+              padding: '1.2rem',
+            }}
+          >
+            <h3 style={{ marginBottom: '0.6rem' }}>Trading Playbooks</h3>
+            <p style={{ color: '#cbd5e1', marginBottom: '0.85rem' }}>
+              Every playbook explains when to trade, entry conditions, risk rules, and example setups.
+            </p>
+            {playbooks.map((playbook) => (
+              <div key={playbook} style={{ display: 'flex', alignItems: 'center', gap: '0.45rem', marginBottom: '0.45rem' }}>
+                <PlayCircle size={15} color="#60a5fa" />
+                <span>{playbook}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
 
-          <div style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(350px, 1fr))',
-            gap: '2rem'
-          }}>
-            {[
-              {
-                initial: 'M',
-                name: 'Marcus R.',
-                role: 'Options Trader, 2 years experience',
-                rating: '⭐⭐⭐⭐⭐',
-                text: 'The ORB strategy alone has completely changed my trading game. I went from losing money consistently to having my best month ever. The signals are spot-on and the community support is incredible.',
-                result: '+$8,500 in 30 days',
-                gradient: 'linear-gradient(to bottom right, #10b981, #2563eb)'
-              },
-              {
-                initial: 'S',
-                name: 'Sarah L.',
-                role: 'Futures Trader, Beginner',
-                rating: '⭐⭐⭐⭐⭐',
-                text: 'As a complete beginner, I was overwhelmed by futures trading. The educational content and live signals gave me the confidence to start trading profitably within my first month.',
-                result: '$2,300 profit as a beginner',
-                gradient: 'linear-gradient(to bottom right, #3b82f6, #a855f7)'
-              },
-              {
-                initial: 'D',
-                name: 'David K.',
-                role: 'Prop Firm Trader',
-                rating: '⭐⭐⭐⭐⭐',
-                text: 'The prop firm insights are pure gold. I passed my evaluation on the second try using the risk management techniques taught here. Now I\'m trading with $100K in firm capital.',
-                result: 'Passed $100K prop firm eval',
-                gradient: 'linear-gradient(to bottom right, #a855f7, #ec4899)'
-              },
-              {
-                initial: 'A',
-                name: 'Amanda T.',
-                role: 'Day Trader, 5 years experience',
-                rating: '⭐⭐⭐⭐⭐',
-                text: 'I\'ve been trading for years but was stuck in a rut. The weekly newsletter and monthly webinars opened my eyes to new strategies. My win rate jumped from 60% to 82%.',
-                result: 'Win rate: 60% → 82%',
-                gradient: 'linear-gradient(to bottom right, #f59e0b, #ef4444)'
-              },
-              {
-                initial: 'J',
-                name: 'James W.',
-                role: 'Options Trader, Side hustle',
-                rating: '⭐⭐⭐⭐⭐',
-                text: 'Working full-time, I needed signals I could trust. The Telegram alerts let me catch profitable moves even during my lunch breaks. Made enough to pay off my car!',
-                result: '$12,000 side income',
-                gradient: 'linear-gradient(to bottom right, #06b6d4, #2563eb)'
-              },
-              {
-                initial: 'R',
-                name: 'Rachel M.',
-                role: 'Former Stock Trader',
-                rating: '⭐⭐⭐⭐⭐',
-                text: 'Transitioning from stocks to options seemed impossible until I found Alpha Trading. The educational content is top-notch and the support is phenomenal. Worth every penny!',
-                result: 'Successful transition to options',
-                gradient: 'linear-gradient(to bottom right, #10b981, #059669)'
-              }
-            ].map((testimonial, index) => (
-              <div key={index} style={{
-                backgroundColor: 'rgba(30, 41, 59, 0.4)',
-                backdropFilter: 'blur(16px)',
-                borderRadius: '0.75rem',
-                padding: '2rem',
-                border: '1px solid rgba(71, 85, 105, 0.5)',
-                transition: 'all 0.3s'
-              }}
-              onMouseOver={(e) => e.currentTarget.style.borderColor = '#10b981'}
-              onMouseOut={(e) => e.currentTarget.style.borderColor = 'rgba(71, 85, 105, 0.5)'}
-              >
-                <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1.5rem' }}>
-                  <div style={{
-                    width: '3rem',
-                    height: '3rem',
-                    background: testimonial.gradient,
-                    borderRadius: '50%',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    color: 'white',
-                    fontWeight: 'bold',
-                    fontSize: '1.125rem'
-                  }}>
-                    {testimonial.initial}
-                  </div>
-                  <div style={{ marginLeft: '1rem' }}>
-                    <div style={{ fontWeight: '600', color: 'white' }}>{testimonial.name}</div>
-                    <div style={{ color: '#64748b', fontSize: '0.875rem' }}>{testimonial.role}</div>
-                  </div>
-                </div>
-                <div style={{ color: '#eab308', marginBottom: '1rem' }}>{testimonial.rating}</div>
-                <p style={{ color: '#cbd5e1', lineHeight: '1.6', marginBottom: '1rem' }}>
-                  {testimonial.text}
-                </p>
-                <div style={{ color: '#10b981', fontWeight: '600' }}>{testimonial.result}</div>
+      <section style={{ padding: '4.5rem 1.5rem' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto', display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1rem' }}>
+          <div style={{ backgroundColor: 'rgba(30, 41, 59, 0.55)', borderRadius: '0.9rem', padding: '1.2rem', border: '1px solid rgba(148,163,184,0.3)' }}>
+            <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}><TrendingUp size={20} color="#34d399" /> The Alpha Trading Pre-Market Routine</h3>
+            <p style={{ color: '#cbd5e1', margin: '0.5rem 0 0.8rem' }}>Preparation reduces emotional decision-making and improves consistency.</p>
+            {routine.map((item) => (
+              <div key={item} style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.4rem' }}>
+                <Target size={15} color="#93c5fd" />
+                <span>{item}</span>
               </div>
             ))}
           </div>
 
-          {/* Trust Indicators */}
-          <div style={{ marginTop: '4rem', textAlign: 'center' }}>
-            <div style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-              gap: '2rem',
-              marginBottom: '3rem'
-            }}>
-              {[
-                { number: '500+', label: 'Happy Subscribers', color: '#10b981' },
-                { number: '85%', label: 'Average Win Rate', color: '#3b82f6' },
-                { number: '$2.1M+', label: 'Total Profits Generated', color: '#a855f7' },
-                { number: '4.9/5', label: 'Customer Rating', color: '#eab308' }
-              ].map((stat, index) => (
-                <div key={index} style={{ textAlign: 'center' }}>
-                  <div style={{ fontSize: '2rem', fontWeight: 'bold', color: stat.color, marginBottom: '0.5rem' }}>{stat.number}</div>
-                  <div style={{ color: '#cbd5e1' }}>{stat.label}</div>
-                </div>
-              ))}
-            </div>
+          <div style={{ backgroundColor: 'rgba(30, 41, 59, 0.55)', borderRadius: '0.9rem', padding: '1.2rem', border: '1px solid rgba(148,163,184,0.3)' }}>
+            <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}><Compass size={20} color="#34d399" /> The Alpha Trading Path</h3>
+            {['Step 1: Learn the foundations', 'Step 2: Build your trading plan', 'Step 3: Practice with structure', 'Step 4: Execute with confidence'].map((step) => (
+              <div key={step} style={{ display: 'flex', gap: '0.5rem', marginTop: '0.6rem' }}>
+                <CheckCircle size={16} color="#22c55e" />
+                <span>{step}</span>
+              </div>
+            ))}
+          </div>
 
-            <div style={{
-              backgroundColor: 'rgba(16, 185, 129, 0.1)',
-              border: '1px solid rgba(16, 185, 129, 0.3)',
-              borderRadius: '1rem',
-              padding: '2rem',
-              maxWidth: '48rem',
-              margin: '0 auto'
-            }}>
-              <h3 style={{ fontSize: '1.5rem', fontWeight: 'bold', marginBottom: '1rem', color: '#10b981' }}>Join the Success Stories</h3>
-              <p style={{ fontSize: '1.125rem', color: '#cbd5e1', marginBottom: '1.5rem' }}>
-                Don't wait – start your journey to consistent trading profits today
-              </p>
-              <button 
-                onClick={handleJoinNow}
-                style={{
-                  background: 'linear-gradient(to right, #10b981, #2563eb)',
-                  color: 'white',
-                  fontWeight: 'bold',
-                  padding: '1rem 2.5rem',
-                  borderRadius: '0.75rem',
-                  fontSize: '1.125rem',
-                  border: 'none',
-                  cursor: 'pointer',
-                  transition: 'all 0.3s',
-                  boxShadow: '0 10px 25px rgba(0, 0, 0, 0.1)'
-                }}
-                onMouseOver={(e) => {
-                  e.target.style.transform = 'scale(1.05)';
-                  e.target.style.boxShadow = '0 10px 25px rgba(16, 185, 129, 0.2)';
-                }}
-                onMouseOut={(e) => {
-                  e.target.style.transform = 'scale(1)';
-                  e.target.style.boxShadow = '0 10px 25px rgba(0, 0, 0, 0.1)';
-                }}
-              >
-                Get Started Now - $159.99/Month
-              </button>
-            </div>
+          <div style={{ backgroundColor: 'rgba(30, 41, 59, 0.55)', borderRadius: '0.9rem', padding: '1.2rem', border: '1px solid rgba(148,163,184,0.3)' }}>
+            <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}><Shield size={20} color="#34d399" /> Why This Mentorship Is Different</h3>
+            <p style={{ color: '#cbd5e1', marginTop: '0.55rem' }}>
+              Most trading groups focus on selling signals. We focus on producing independent traders who can identify
+              setups, manage risk, journal performance, and adapt to changing market conditions.
+            </p>
           </div>
         </div>
       </section>
 
-      {/* Final CTA Section */}
-      <section style={{
-        padding: '5rem 0',
-        background: 'linear-gradient(to right, #10b981, #2563eb)'
-      }}>
-        <div style={{ maxWidth: '64rem', margin: '0 auto', padding: '0 1.5rem', textAlign: 'center' }}>
-          <h2 style={{ fontSize: 'clamp(2rem, 5vw, 3rem)', fontWeight: 'bold', marginBottom: '1.5rem' }}>
-            Don't Trade Alone – Get Signals & Strategies That Work
-          </h2>
-          
-          <p style={{ fontSize: '1.25rem', marginBottom: '3rem', opacity: 0.9 }}>
-            Join Alpha Trading today and start your journey towards consistent profitability
-          </p>
-          
-          <button 
-            onClick={handleJoinNow}
-            style={{
-              backgroundColor: 'white',
-              color: '#10b981',
-              fontWeight: 'bold',
-              padding: '1.5rem 3rem',
-              borderRadius: '0.75rem',
-              fontSize: '1.25rem',
-              border: 'none',
-              cursor: 'pointer',
-              transition: 'all 0.3s',
-              boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)'
-            }}
-            onMouseOver={(e) => {
-              e.target.style.backgroundColor = '#f1f5f9';
-              e.target.style.transform = 'scale(1.05)';
-            }}
-            onMouseOut={(e) => {
-              e.target.style.backgroundColor = 'white';
-              e.target.style.transform = 'scale(1)';
-            }}
-          >
-            Join Alpha Trading Today
-          </button>
+      <section style={{ padding: '0 1.5rem 4rem' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <h2 style={{ marginBottom: '1rem' }}>Book a Demo / Intro Session</h2>
+          <div style={{ backgroundColor: 'rgba(30, 41, 59, 0.55)', borderRadius: '0.9rem', padding: '1.1rem', border: '1px solid rgba(148,163,184,0.3)' }}>
+            <p style={{ color: '#cbd5e1', marginBottom: '0.7rem' }}>
+              We use intro sessions to align expectations, assess fit, and ensure each member can complete the program.
+              If we detect red flags during the conversation, we may decline enrollment to protect community quality.
+            </p>
+            <button
+              onClick={handleBookIntro}
+              style={{
+                border: 'none',
+                cursor: 'pointer',
+                borderRadius: '0.75rem',
+                padding: '0.8rem 1.2rem',
+                background: 'linear-gradient(90deg, #10b981, #2563eb)',
+                color: 'white',
+                fontWeight: 700,
+              }}
+            >
+              Open Calendly
+            </button>
+          </div>
         </div>
       </section>
 
-      {/* Floating Contact Button */}
-      <div style={{
-        position: 'fixed',
-        bottom: '1.5rem',
-        right: '1.5rem',
-        zIndex: 50
-      }}>
-        <a 
-          href="mailto:info@alphadatacapital.com?subject=Support Request"
-          style={{
-            backgroundColor: '#3b82f6',
-            color: 'white',
-            padding: '1rem',
-            borderRadius: '50%',
-            boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
-            transition: 'all 0.3s',
-            display: 'block'
-          }}
-          onMouseOver={(e) => {
-            e.target.style.backgroundColor = '#2563eb';
-            e.target.style.transform = 'scale(1.1)';
-          }}
-          onMouseOut={(e) => {
-            e.target.style.backgroundColor = '#3b82f6';
-            e.target.style.transform = 'scale(1)';
-          }}
-        >
-          <MessageCircle style={{ width: '1.5rem', height: '1.5rem' }} />
-        </a>
-      </div>
+      <section style={{ padding: '0 1.5rem 4rem' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <h2 style={{ marginBottom: '1rem' }}>Student Wins & Testimonials</h2>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '1rem' }}>
+            {[
+              '“I stopped chasing alerts and finally learned why trades work.”',
+              '“My confidence improved because I now have a repeatable routine.”',
+              '“Journaling and mentorship feedback changed my execution.”',
+            ].map((quote) => (
+              <div key={quote} style={{ backgroundColor: 'rgba(30, 41, 59, 0.55)', borderRadius: '0.9rem', padding: '1rem', border: '1px solid rgba(148,163,184,0.3)' }}>
+                <MessageSquare size={16} color="#93c5fd" />
+                <p style={{ marginTop: '0.6rem', color: '#e2e8f0' }}>{quote}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
 
-      <style dangerouslySetInnerHTML={{
-        __html: `
-          @keyframes bounce {
-            0%, 100% { transform: translateY(0px); }
-            50% { transform: translateY(-20px); }
-          }
-        `
-      }} />
+      <footer style={{ borderTop: '1px solid rgba(148,163,184,0.25)', padding: '1.2rem 1.5rem 2.3rem' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto', display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <img src="/Alpha Trading.png" alt="Alpha Trading logo" style={{ width: '1.6rem', height: '1.6rem' }} />
+            <strong>Alpha Trading Pro</strong>
+          </div>
+          <p style={{ color: '#94a3b8', maxWidth: '720px' }}>
+            Disclaimer: All content is for educational purposes only and does not constitute investment or financial
+            advice. Trading involves risk and may result in loss of capital.
+          </p>
+        </div>
+      </footer>
     </div>
   );
 };
+
+const InfoCard = ({ icon: Icon, title, items }) => (
+  <div
+    style={{
+      backgroundColor: 'rgba(30, 41, 59, 0.55)',
+      border: '1px solid rgba(148, 163, 184, 0.25)',
+      borderRadius: '0.9rem',
+      padding: '1.2rem',
+    }}
+  >
+    <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.65rem' }}>
+      <Icon size={20} color="#34d399" /> {title}
+    </h3>
+    {items.map((item) => (
+      <div key={item} style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.4rem' }}>
+        <BarChart3 size={15} color="#93c5fd" style={{ marginTop: '0.2rem' }} />
+        <span style={{ color: '#e2e8f0', fontSize: '0.95rem' }}>{item}</span>
+      </div>
+    ))}
+  </div>
+);
 
 export default AlphaTradingLanding;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,90 +1,79 @@
-import Head from 'next/head'
-import AlphaTradingLanding from '../components/AlphaTradingLanding'
+import Head from 'next/head';
+import AlphaTradingLanding from '../components/AlphaTradingLanding';
 
 export default function Home() {
   return (
     <>
       <Head>
-        <title>Alpha Trading Pros - Live Trading Signals & Options Education | $159.99/Month</title>
-        <meta name="description" content="Get live trading signals, monthly webinars, and exclusive educational resources for options and futures trading. Join 500+ successful traders with 85% win rate. Subscribe for $159.99/month." />
-        
-        {/* SEO Keywords */}
-        <meta name="keywords" content="trading signals, options trading, futures trading, trading education, prop firm trading, ORB strategy, trading subscription, live trading alerts, trading webinars, options signals, day trading, swing trading" />
-        
-        {/* Viewport and basics */}
+        <title>Alpha Trading Pro | Trading Mentorship, Education & Algo Tools</title>
+        <meta
+          name="description"
+          content="Alpha Trading Pro offers structured trading mentorship for options and futures, community coaching, and AI-assisted market scanning tools to help traders build skill and discipline."
+        />
+        <meta
+          name="keywords"
+          content="trading mentorship, learn stock trading, day trading course, small cap trading strategy, stock scanner strategies, momentum trading strategies, how to trade stocks"
+        />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="robots" content="index, follow" />
-        <meta name="author" content="Alpha Trading Pros" />
+        <meta name="author" content="Alpha Trading Pro" />
         <link rel="canonical" href="https://alphatradingpros.com" />
-        
-        {/* Favicon */}
         <link rel="icon" href="/Alpha Trading.png" />
         <link rel="apple-touch-icon" href="/Alpha Trading.png" />
-        
-        {/* Open Graph / Facebook */}
+
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://alphatradingpros.com/" />
-        <meta property="og:title" content="Alpha Trading Pros - Live Trading Signals & Options Education" />
-        <meta property="og:description" content="Join 500+ successful traders with 85% win rate. Get live trading signals, monthly webinars, and exclusive educational resources for options and futures trading." />
+        <meta property="og:title" content="Alpha Trading Pro | Mentorship and Structured Trading Education" />
+        <meta
+          property="og:description"
+          content="Learn to trade with structure, discipline, and confidence through mentorship, strategy playbooks, and AI-assisted tools."
+        />
         <meta property="og:image" content="https://alphatradingpros.com/Alpha Trading.png" />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image:height" content="630" />
-        <meta property="og:site_name" content="Alpha Trading Pros" />
+        <meta property="og:site_name" content="Alpha Trading Pro" />
 
-        {/* Twitter */}
         <meta property="twitter:card" content="summary_large_image" />
-        <meta property="twitter:site" content="@AlphaTradingHQ" />
-        <meta property="twitter:creator" content="@AlphaTradingHQ" />
-        <meta property="twitter:url" content="https://alphatradingpros.com/" />
-        <meta property="twitter:title" content="Alpha Trading Pros - Live Trading Signals & Options Education" />
-        <meta property="twitter:description" content="Join 500+ successful traders with 85% win rate. Get live trading signals and exclusive educational resources." />
+        <meta property="twitter:title" content="Alpha Trading Pro | Trading Mentorship" />
+        <meta
+          property="twitter:description"
+          content="Structured mentorship for options and futures traders focused on discipline, market structure, and repeatable execution."
+        />
         <meta property="twitter:image" content="https://alphatradingpros.com/Alpha Trading.png" />
 
-        {/* Additional SEO */}
         <meta name="theme-color" content="#10b981" />
         <meta name="msapplication-TileColor" content="#10b981" />
-        
-        {/* Schema.org structured data */}
-        <script 
+
+        <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify({
-              "@context": "https://schema.org",
-              "@type": "Organization",
-              "name": "Alpha Trading Pros",
-              "url": "https://alphatradingpros.com",
-              "logo": "https://alphatradingpros.com/Alpha Trading.png",
-              "description": "Professional trading signals and education for options and futures traders",
-              "founder": {
-                "@type": "Person",
-                "name": "Alpha Trading Pros Team"
+              '@context': 'https://schema.org',
+              '@type': 'EducationalOrganization',
+              name: 'Alpha Trading Pro',
+              url: 'https://alphatradingpros.com',
+              logo: 'https://alphatradingpros.com/Alpha Trading.png',
+              description:
+                'A structured options and futures trading mentorship program focused on market structure, discipline, strategy playbooks, and AI-assisted market scanning tools.',
+              offers: {
+                '@type': 'OfferCatalog',
+                name: 'Alpha Trading Programs',
+                itemListElement: [
+                  {
+                    '@type': 'Offer',
+                    name: 'Trading Mentorship Program',
+                    description: 'Structured education, live mentorship sessions, and community coaching.',
+                  },
+                  {
+                    '@type': 'Offer',
+                    name: 'AI-Assisted Market Scanning Tools',
+                    description: 'Algorithmic scanners and alerts designed to support trader decision-making.',
+                  },
+                ],
               },
-              "offers": {
-                "@type": "Offer",
-                "name": "Alpha Trading Subscription",
-                "price": "159.99",
-                "priceCurrency": "USD",
-                "priceValidUntil": "2025-12-31",
-                "itemCondition": "https://schema.org/NewCondition",
-                "availability": "https://schema.org/InStock",
-                "url": "https://alphatradingpros.com",
-                "description": "Monthly subscription for live trading signals, webinars, and educational resources"
-              },
-              "contactPoint": {
-                "@type": "ContactPoint",
-                "contactType": "customer service",
-                "email": "info@alphadatacapital.com"
-              },
-              "sameAs": [
-                "https://x.com/AlphaTradingHQ",
-                "https://instagram.com/alphatradinghq",
-                "https://alphatradingpros.com"
-              ]
-            })
+            }),
           }}
         />
       </Head>
       <AlphaTradingLanding />
     </>
-  )
+  );
 }


### PR DESCRIPTION
### Motivation
- Shift the site from a signals/subscription pitch to a mentorship-first product offering focused on education, discipline, and tooling. 
- Replace the hard subscription CTA with a consultative booking flow and clearer product positioning for mentorship, playbooks, and algo tools. 
- Improve SEO and structured data to reflect an educational/mentorship service rather than a pure signals product. 

### Description
- Rewrote `components/AlphaTradingLanding.js` to present a mentorship-focused layout, replacing prior subscription-heavy content with sections for pillars, modules, tiers, playbooks, routines, tools, and testimonials.  
- Added constants (`pillars`, `mentorshipModules`, `mentorshipTiers`, `playbooks`, `routine`, `botFeatures`) and a `calendlyUrl` and replaced the Stripe subscribe flow with `handleBookIntro` that opens Calendly via `window.open`.  
- Reworked navigation, hero, cards and visual styles; removed floating contact CTA and numerous old subscription elements, and added a reusable `InfoCard` component at the bottom of the file.  
- Updated icon imports from `lucide-react` and used new icons across the landing UI.  
- Modified `pages/index.js` metadata: updated `<title>`, `description`, `keywords`, Open Graph/Twitter tags, `author`, and replaced the previous Organization JSON-LD with an `EducationalOrganization`-focused schema and `OfferCatalog`.  

### Testing
- Ran a production build with `npm run build` / `next build`, which completed successfully.  
- Ran the linter with `npm run lint`, which reported no new lint errors.  
- Performed an automated static check of the head/meta JSON-LD injection (via build) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8a237303c833083062ed1dcbc81bc)